### PR TITLE
support new session increment feature

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -41,6 +41,10 @@ exports.identify = function(msg){
     ret.unsubscribed_from_emails = context.unsubscribedFromEmails;
   }
 
+  // Increment User sessions
+  // https://developers.intercom.io/reference#incrementing-user-sessions
+  if (context.newSession) ret.new_session = true;
+
   // Add company data
   var companies = dot(traits, 'companies');
   var company = dot(traits, 'company');

--- a/test/fixtures/identify-new-session.json
+++ b/test/fixtures/identify-new-session.json
@@ -1,0 +1,35 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "integrations": {
+      "Intercom": {
+        "unsubscribedFromEmails": true,
+        "newSession": true
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "name": "john doe",
+    "unsubscribed_from_emails": true,
+    "new_session": true,
+    "custom_attributes": {
+      "created_at": 1388534400,
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,10 @@ describe('Intercom', function(){
         test.maps('identify-active');
       });
 
+      it('should respect new session flag', function(){
+        test.maps('identify-new-session');
+      });
+
       it('should map nested dates', function(){
         test.maps('identify-nested-dates');
       });


### PR DESCRIPTION
Fixes https://github.com/segment-integrations/integration-intercom/issues/3

Lets users add an optional flag called `newSession` in Intercom specific integration settings that will increment the user session as noted in [Intercom docs](https://developers.intercom.io/reference#incrementing-user-sessions). I'm not using `traits` since this isn't something that is spec'd nor would this `trait` hold any semantic meaning across other integrations.

So a user would have to call:

```
analytics.identify({
  userId: '019mr8mf4r',
  traits: {
    name: 'Michael Bolton',
    email: 'mbolton@initech.com',
    plan: 'Enterprise',
    friends: 42
  },
  integrations: {
    Intercom: {
      newSession: true
    }
  }
});
```

I was thinking to use the `.active()` but looks like we are already using that flag for setting `last_request_at` [here](https://github.com/segment-integrations/integration-intercom/blob/master/lib/mapper.js#L31). I don't want to combine two features into one flag and the way our facade says `.active()` is to "check if a user is active" which probably is more inline with `last_request_at`. 

@segment-integrations/core 
