### PR TITLE
fixed nesting of company object from identify calls

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -63,7 +63,8 @@ exports.identify = function(msg, settings) {
 
   if (company) companies = [company];
   if (is.array(companies)) ret.companies = companies.map(formatCompany);
-
+  delete ret.custom_attributes.companies;
+  
   return ret;
 };
 

--- a/test/fixtures/identify-companies-remove.json
+++ b/test/fixtures/identify-companies-remove.json
@@ -16,12 +16,6 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "companies": [{
-        "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123",
-        "remove": true
-      }],
       "id": "user-id"
     },
     "companies": [{

--- a/test/fixtures/identify-companies.json
+++ b/test/fixtures/identify-companies.json
@@ -15,11 +15,6 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "companies": [{
-        "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123"
-      }],
       "id": "user-id"
     },
     "companies": [{


### PR DESCRIPTION
The company object was nested inside of the top level custom_attributes in the identify call which was causing intercom to reject the message. When looking at the Intercom integration that runs from the javascript client it appears to be doing this properly but unfortunately I need to use the Ruby client in some cases.