### PR TITLE
flatten custom attrs and remove redundant company fields in custom attrs

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -6,6 +6,7 @@ var isostring = require('isostring');
 var hash = require('string-hash');
 var time = require('unix-time');
 var dot = require('obj-case');
+var flatten = require('flat');
 var is = require('is');
 
 /**
@@ -64,6 +65,10 @@ exports.identify = function(msg, settings) {
   if (company) companies = [company];
   if (is.array(companies)) ret.companies = companies.map(formatCompany);
 
+  delete ret.custom_attributes.company;
+  delete ret.custom_attributes.companies;
+  ret.custom_attributes = flatten(ret.custom_attributes);
+
   return ret;
 };
 
@@ -100,6 +105,9 @@ exports.group = function(msg) {
   ret.monthly_spend = msg.proxy('traits.monthlySpend');
   ret.plan = msg.proxy('traits.plan');
   ret.custom_attributes = formatTraits(msg.traits());
+  delete ret.custom_attributes.companies;
+  delete ret.custom_attributes.company;
+  ret.custom_attributes = flatten(ret.custom_attributes);
   return ret;
 };
 
@@ -116,17 +124,21 @@ exports.group = function(msg) {
  */
 
 function formatCompany(company) {
-  if (is.string(company)) company = {name: company};
+  if (is.string(company)) company = { name: company };
 
   var ret = {};
   ret.name = company.name;
-  ret.custom_attributes = company;
 
   if (company.id) {
     ret.company_id = company.id;
+    delete company.id;
   } else if (company.name) {
     ret.company_id = hash(company.name);
   }
+
+  delete company.name;
+
+  if (company !== undefined) ret.custom_attributes = company;
 
   // https://doc.intercom.io/api/#companies-and-users
   if (company.remove) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "extend": "^2.0.0",
     "is": "^2.1.0",
     "isostring": "0.0.1",
+    "flat": "2.0.1",
     "obj-case": "^0.1.1",
     "segmentio-facade": "^2.0.5",
     "segmentio-integration": "^5.0.1",

--- a/test/fixtures/identify-companies-remove.json
+++ b/test/fixtures/identify-companies-remove.json
@@ -16,20 +16,12 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "companies": [{
-        "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123",
-        "remove": true
-      }],
       "id": "user-id"
     },
     "companies": [{
       "remote_created_at": 1388534400,
       "custom_attributes": {
         "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123",
         "remove": true
       },
       "company_id": "123",

--- a/test/fixtures/identify-companies.json
+++ b/test/fixtures/identify-companies.json
@@ -15,19 +15,12 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "companies": [{
-        "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123"
-      }],
       "id": "user-id"
     },
     "companies": [{
       "remote_created_at": 1388534400,
       "custom_attributes": {
-        "created_at": 1388534400,
-        "name": "Segment",
-        "id": "123"
+        "created_at": 1388534400
       },
       "company_id": "123",
       "name": "Segment"

--- a/test/fixtures/identify-company-remove.json
+++ b/test/fixtures/identify-company-remove.json
@@ -14,15 +14,10 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "company": {
-          "name": "Segment",
-          "remove": true
-      },
       "id": "user-id"
     },
     "companies": [{
       "custom_attributes": {
-        "name": "Segment",
         "remove": true
       },
       "company_id": 2017828326,

--- a/test/fixtures/identify-company.json
+++ b/test/fixtures/identify-company.json
@@ -11,14 +11,11 @@
     "user_id": "user-id",
     "last_request_at": 1388534400,
     "custom_attributes": {
-      "company": "Segment",
       "id": "user-id"
     },
     "companies": [{
-      "custom_attributes": {
-        "name": "Segment"
-      },
       "company_id": 2017828326,
+      "custom_attributes": {},
       "name": "Segment"
     }]
   }

--- a/test/fixtures/identify-nested-dates.json
+++ b/test/fixtures/identify-nested-dates.json
@@ -26,10 +26,8 @@
       "firstName": "john",
       "lastName": "doe",
       "id": "user-id",
-      "race": {
-        "finish_at": 1388620800,
-        "start_at":  1388534400
-      }
+      "race.finish_at": 1388620800,
+      "race.start_at": 1388534400
     }
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -161,12 +161,6 @@ exports.identify = function (options) {
       city        : 'San Francisco',
       state       : 'CA',
       phone       : '5555555555',
-      websites    : [
-        'http://calv.info',
-        'http://ianstormtaylor.com',
-        'http://ivolo.me',
-        'http://rein.pk'
-      ],
       bad     : null,
       alsoBad : undefined,
       met : (new Date()).toISOString(),

--- a/test/index.js
+++ b/test/index.js
@@ -139,16 +139,19 @@ describe('Intercom', function(){
     it('should be able to identify correctly', function(done){
       var msg = helpers.identify();
 
+      var traits = intercom.formatTraits(msg.traits());
+      delete traits.company;
+
       payload.user_id = msg.userId();
       payload.remote_created_at = time(msg.created());
       payload.last_request_at = time(msg.timestamp());
       payload.last_seen_ip = msg.ip();
       payload.email = msg.email();
       payload.name = msg.name();
-      payload.custom_attributes = intercom.formatTraits(msg.traits());
+      payload.custom_attributes = traits;
       payload.companies = [{
         company_id: hash('Segment.io'),
-        custom_attributes: { name: 'Segment.io' },
+        custom_attributes: {},
         name: 'Segment.io'
       }];
 
@@ -208,18 +211,20 @@ describe('Intercom', function(){
       var input = test.fixture('group-basic').input;
       input.traits.created_at = time(new Date(input.traits.created_at));
 
+      var name = input.traits.name;
+      delete input.traits.name;
+
       var payload = {};
       payload.user_id = input.userId;
       payload.last_request_at = time(input.timestamp);
       payload.companies = [{
         company_id: input.groupId,
         custom_attributes: input.traits,
-        name: input.traits.name,
+        name: name,
         remote_created_at: input.traits.created_at
       }];
-      payload.companies[0].custom_attributes.id = input.groupId;
+
       payload.custom_attributes = {
-        companies: [payload.companies[0].custom_attributes],
         id: input.userId
       };
 


### PR DESCRIPTION
Intercom's endpoint began rejecting any calls with nested objects or arrays in user or company-related `custom_attributes` fields. 

- removes company information in user custom attrs (which is fine, this was always redundant since company has a special top level field)

- in the `companies` top level field, removed `name` and `id` from the `company.custom_attributes` fields as they have top level fields within the `company` object

- flattens `custom_attributes` in user and company objects before sending

@hankim813 @WesleyDRobinson @jgershen @tsholmes 

related docs:
https://developers.intercom.com/reference#create-or-update-user
https://developers.intercom.com/reference#create-or-update-company