### PR TITLE
EPD-1115

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,13 @@
 
+2.1.1 / 2016-12-20
+===================
+
+  * Move traits.phone into top level standard attr rather than custom_attributes
+
 2.1.0 / 2016-11-14
 ===================
 
-  * Remove redudant traits that were mapped semantically already for identify calls 
+  * Remove redudant traits that were mapped semantically already for identify calls
 
 2.0.0 / 2016-11-07
 ===================

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -67,9 +67,13 @@ exports.identify = function(msg, settings){
   company = formatCompany(company); // returns array
   if (company.length) ret.companies = company;
 
+  // Add phone data
+  if (msg.phone()) ret.phone = msg.phone();
+
   // Delete dupes
   remove(ret.custom_attributes, 'company');
   remove(ret.custom_attributes, 'companies');
+  remove(ret.custom_attributes, 'phone');
 
   // Must flatten any nested data structures to prevent Intercom rejecting the message
   ret.custom_attributes = flatten(ret.custom_attributes);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-intercom",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "integration-version": "2016-11-07",
   "private": true,
   "description": "Intercom server-side integration",

--- a/test/fixtures/identify-phone.json
+++ b/test/fixtures/identify-phone.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "hansolodolo",
+    "timestamp": "2016",
+    "traits": {
+      "email": "han@hansolo.com",
+      "phone": "4012229047",
+      "firstName": "han",
+      "lastName": "kim"
+    }
+  },
+  "output": {
+    "user_id": "hansolodolo",
+    "email": "han@hansolo.com",
+    "last_request_at": 1451606400,
+    "name": "han kim",
+    "phone": "4012229047",
+    "custom_attributes": {
+      "email": "han@hansolo.com",
+      "firstName": "han",
+      "lastName": "kim",
+      "id": "hansolodolo"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,10 @@ describe('Intercom', function(){
         test.maps('identify-company');
       });
 
+      it('should map phone', function(){
+        test.maps('identify-phone');
+      });
+
       it('should map companies with remove', function(){
         test.maps('identify-companies-remove');
       });
@@ -154,6 +158,7 @@ describe('Intercom', function(){
 
       var traits = intercom.formatTraits(msg.traits());
       delete traits.company;
+      delete traits.phone;
 
       payload.user_id = msg.userId();
       payload.remote_created_at = time(msg.created());
@@ -161,6 +166,7 @@ describe('Intercom', function(){
       payload.last_seen_ip = msg.ip();
       payload.email = msg.email();
       payload.name = msg.name();
+      payload.phone = msg.phone();
       payload.custom_attributes = traits;
       payload.companies = [{
         company_id: hash('Segment.io'),
@@ -192,6 +198,17 @@ describe('Intercom', function(){
         should.not.exist(err);
         done();
       });
+    });
+
+    it('should send phone properly', function(done){
+      var json = test.fixture('identify-phone');
+
+      test
+        .set(settings)
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
     });
 
     it('should send the ip address', function(done){


### PR DESCRIPTION
Intercom now has `phone` as a standard attribute so this PR removes that trait from `custom_attributes` and puts them at the top level of the payload.

Docs: https://developers.intercom.com/reference#user-model

E2E testing:

![](https://i.gyazo.com/d608e43a0ed0f2b95b5eacc017674fb5.png)

- [ ] deploy this
- [ ] deploy [`2016-10-26` branch PR](https://github.com/segment-integrations/integration-intercom/pull/37)

@tsholmes @amnoonan 