### PR TITLE
Updated created and remote_created_at attributes and tests

### DIFF
--- a/lib/mapper-v1.js
+++ b/lib/mapper-v1.js
@@ -35,6 +35,8 @@ exports.identify = function(msg, settings) {
   ret.user_id = msg.userId();
   ret.custom_attributes = traits;
 
+  // https://developers.intercom.com/v2.0/reference#user-model
+  // "created_at": populates the "Signed Up" attribute in Intercom's user dashboard
   var created = time(msg.created())
 
   if (created) {
@@ -43,6 +45,9 @@ exports.identify = function(msg, settings) {
     remove(ret.custom_attributes, 'createdAt');
   }
 
+  // "remote_created_at": optional attribute representing time a user
+  // was created by you; doesn't populate to Intercom's dashboard, but is
+  // available when querying their API
   var remoteCreated = traits.remote_created_at || traits.remoteCreatedAt;
 
   if (remoteCreated) {

--- a/lib/mapper-v1.js
+++ b/lib/mapper-v1.js
@@ -15,6 +15,7 @@ var each = require('@ndhoule/each');
 var remove = require('obj-case').del;
 var extend = require('@ndhoule/extend');
 var reject = require('reject');
+var newDate = require('new-date');
 
 /**
  * Map identify `msg`.
@@ -34,7 +35,25 @@ exports.identify = function(msg, settings) {
   ret.user_id = msg.userId();
   ret.custom_attributes = traits;
 
-  if (msg.created()) ret.remote_created_at = time(msg.created());
+  var created = time(msg.created())
+
+  if (created) {
+    ret.created_at = created;
+    remove(ret.custom_attributes, 'created_at');
+    remove(ret.custom_attributes, 'createdAt');
+  }
+
+  var remoteCreated = traits.remote_created_at || traits.remoteCreatedAt;
+
+  if (remoteCreated) {
+    var formatted_remote_created = newDate(remoteCreated);
+    ret.remote_created_at = time(formatted_remote_created);
+
+    // delete dupes
+    remove(traits, 'remote_created_at');
+    remove(traits, 'remoteCreatedAt');
+  }
+
   if (active) ret.last_request_at = traits.lastRequestAt || time(msg.timestamp());
   if (traits.lastRequestAt) remove(traits, 'lastRequestAt');
   if (msg.ip()) ret.last_seen_ip = msg.ip();

--- a/test/fixtures/identify-active-v1.json
+++ b/test/fixtures/identify-active-v1.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "createdAt": "2014-01-01",
+      "remoteCreatedAt": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "active": false
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/fixtures/identify-basic-v1.json
+++ b/test/fixtures/identify-basic-v1.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/fixtures/identify-collect-context-v1.json
+++ b/test/fixtures/identify-collect-context-v1.json
@@ -1,0 +1,53 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "ip": "0.0.0.0",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+      "device": {
+        "type": "ios",
+        "manufacturer": "Apple",
+        "model": "iPhone8,2"
+      },
+      "os": {
+        "name": "iPhone OS",
+        "version": "9.3.2"
+      },
+      "app": {
+        "name": "Pokemon Go",
+        "version": "1.1.1"
+      }
+    }
+  },
+  "output": {
+    "last_seen_ip": "0.0.0.0",
+    "last_seen_user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id",
+      "device_type": "ios",
+      "device_manufacturer": "Apple",
+      "device_model": "iPhone8,2",
+      "os_name": "iPhone OS",
+      "os_version": "9.3.2",
+      "app_name": "Pokemon Go",
+      "app_version": "1.1.1"
+    }
+  }
+}

--- a/test/fixtures/identify-context-v1.json
+++ b/test/fixtures/identify-context-v1.json
@@ -1,0 +1,46 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "ip": "0.0.0.0",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+      "device": {
+        "type": "ios",
+        "manufacturer": "Apple",
+        "model": "iPhone8,2"
+      },
+      "os": {
+        "name": "iPhone OS",
+        "version": "9.3.2"
+      },
+      "app": {
+        "name": "Pokemon Go",
+        "version": "1.1.1"
+      }
+    }
+  },
+  "output": {
+    "last_seen_ip": "0.0.0.0",
+    "last_seen_user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/fixtures/identify-last-request-at-v1.json
+++ b/test/fixtures/identify-last-request-at-v1.json
@@ -1,0 +1,28 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe",
+      "lastRequestAt": "2014-02-01"
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1391212800,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/fixtures/identify-last-seen-user-agent-v1.json
+++ b/test/fixtures/identify-last-seen-user-agent-v1.json
@@ -1,0 +1,31 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "last_seen_user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/fixtures/identify-nested-dates-v1.json
+++ b/test/fixtures/identify-nested-dates-v1.json
@@ -1,0 +1,33 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe",
+      "race": {
+        "finish": "2014-01-02",
+        "start": "2014-01-01"
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id",
+      "race.finish_at": 1388620800,
+      "race.start_at": 1388534400
+    }
+  }
+}

--- a/test/fixtures/identify-unsubscribed-from-emails-v1.json
+++ b/test/fixtures/identify-unsubscribed-from-emails-v1.json
@@ -1,0 +1,33 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "remote_created_at": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "integrations": {
+      "Intercom": {
+        "unsubscribedFromEmails": true
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "created_at": 1388534400,
+    "name": "john doe",
+    "unsubscribed_from_emails": true,
+    "custom_attributes": {
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -744,24 +744,24 @@ describe('Intercom V1', function(){
   describe('mapper', function(){
     describe('identify', function(){
       it('should map basic identify', function(){
-        test.maps('identify-basic');
+        test.maps('identify-basic-v1');
       });
 
       it('should map basic context', function(){
-        test.maps('identify-context');
+        test.maps('identify-context-v1');
       });
 
       it('should map additional context if collectContext', function () {
         settings.collectContext = true;
-        test.maps('identify-collect-context')
+        test.maps('identify-collect-context-v1')
       });
 
       it('should respect .active()', function(){
-        test.maps('identify-active');
+        test.maps('identify-active-v1');
       });
 
       it('should map nested dates', function(){
-        test.maps('identify-nested-dates');
+        test.maps('identify-nested-dates-v1');
       });
 
       it('should map companies', function(){
@@ -789,15 +789,15 @@ describe('Intercom V1', function(){
       });
 
       it('should update last_request_at with lastRequestAt when supplied', function(){
-        test.maps('identify-last-request-at');
+        test.maps('identify-last-request-at-v1');
       });
 
       it('should update last_seen_user_agent with userAgent when supplied', function(){
-        test.maps('identify-last-seen-user-agent');
+        test.maps('identify-last-seen-user-agent-v1');
       });
 
       it('should update unsubscribed_from_emails with unsubscribedFromEmails when supplied', function(){
-        test.maps('identify-unsubscribed-from-emails');
+        test.maps('identify-unsubscribed-from-emails-v1');
       });
     });
 
@@ -827,9 +827,10 @@ describe('Intercom V1', function(){
       delete traits.company;
       delete traits.phone;
       delete traits.email;
+      delete traits.created_at;
 
+      payload.created_at = time(msg.created());
       payload.user_id = msg.userId();
-      payload.remote_created_at = time(msg.created());
       payload.last_request_at = time(msg.timestamp());
       payload.last_seen_ip = msg.ip();
       payload.last_seen_user_agent = msg.userAgent();


### PR DESCRIPTION
Standardizes how we map `created_at` across client/server-side per this  JIRA issue: https://segment.atlassian.net/browse/EPD-1081. Also corrects how we send `remote_created_at` standard attribute for *user* profiles server-side. @hankim813 @anoonan @ladanazita 